### PR TITLE
[feat] Hacker News API 레이어 구현 

### DIFF
--- a/src/shared/constants/pageSize.ts
+++ b/src/shared/constants/pageSize.ts
@@ -1,0 +1,1 @@
+export const PAGE_SIZE = 12;

--- a/src/shared/lib/api.ts
+++ b/src/shared/lib/api.ts
@@ -1,0 +1,19 @@
+import { HackerNewsItem, StoryTab } from '@/shared/types/hackerNews';
+
+const BASE_URL = 'https://hacker-news.firebaseio.com/v0';
+
+export const fetchStoryIds = async (tab: StoryTab): Promise<number[]> => {
+  const res = await fetch(`${BASE_URL}/${tab}stories.json`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${tab} stories`);
+  }
+  return res.json();
+};
+
+export const fetchStory = async (id: number): Promise<HackerNewsItem> => {
+  const res = await fetch(`${BASE_URL}/item/${id}.json`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch story ${id}`);
+  }
+  return res.json();
+};

--- a/src/shared/types/hackerNews.ts
+++ b/src/shared/types/hackerNews.ts
@@ -1,0 +1,10 @@
+export type StoryTab = 'top' | 'new' | 'best';
+
+export interface HackerNewsItem {
+  id: number;
+  title: string;
+  by: string;
+  time: number;
+  score: number;
+  url?: string;
+}


### PR DESCRIPTION
## 📌 PR 개요

Hacker News API 연동을 위한 공유 레이어를 구성합니다.
타입 정의, API fetch 함수, 상수를 세팅해 이후 기능 개발의 기반을 마련합니다.

## 🔍 관련 이슈

Closes #2

## 🔧 PR 유형

- [x] ✨ feat (새로운 기능)

## ✨ 변경 사항

### `src/shared/types/hackerNews.ts`

- `StoryTab` — `'top' | 'new' | 'best'` 탭 유니온 타입 정의
- `HackerNewsItem` — API 응답에서 실제 사용하는 필드만 선언

### `src/shared/lib/api.ts`

- `fetchStoryIds(tab)` — 탭별 스토리 ID 목록 fetch
- `fetchStory(id)` — 개별 스토리 상세 fetch
- React Query의 에러 처리에 위임하는 단순 구조 채택

### `src/shared/constants/pageSize.ts`

- `PAGE_SIZE = 12` — 무한 스크롤 페이지당 아이템 수

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

- `HackerNewsItem`은 API 전체 스펙을 미러링하지 않고 실제 렌더링에 필요한 필드만 정의했습니다.
- API 함수는 별도 래퍼 없이 `fetch`를 직접 사용합니다. 캐싱/에러 상태는 TanStack Query에 위임합니다.
