### PR TITLE
[Fix] OS 다크모드 설정 시 UI가 검정 배경으로 표시되는 문제

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,12 @@
   --color-white: #fff;
 }
 
+:root {
+  color-scheme: light;
+}
+
 body {
   font-family: var(--font-sans);
+  background-color: var(--color-white);
+  color: var(--color-gray-900);
 }


### PR DESCRIPTION
## 📌 PR 개요

OS 다크모드 환경에서 전체 배경이 검정으로 표시되는 버그를 수정합니다. Tailwind CSS v4의 Preflight가 `color-scheme: light dark`를 자동 주입하는 것을 `color-scheme: light`로 오버라이드하고, `body`에 명시적 배경색과 텍스트 색상을 지정하여 라이트모드 전용으로 고정합니다.

## 🔍 관련 이슈

Closes #8

## 🔧 PR 유형
- [x] 🐛 fix (버그 수정)

## ✨ 변경 사항

### `globals.css` — 라이트모드 강제 설정

- `:root`에 `color-scheme: light` 추가
  - Tailwind v4 Preflight의 `light dark` 기본값을 오버라이드하여 OS 다크모드 자동 적용 차단
- `body`에 `background-color: var(--color-white)`, `color: var(--color-gray-900)` 명시
  - 브라우저가 기본 다크 색상을 적용하지 못하도록 명시적 폴백 설정

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

Tailwind CSS v4는 `@import 'tailwindcss'` 만으로 Preflight를 자동 포함하며, 이 Preflight에 `color-scheme: light dark`가 내장되어 있습니다. 다크모드를 지원할 계획이 생기면 `:root`의 `color-scheme` 값을 되돌리고 `dark:` variant를 활용하면 됩니다.
