### PR TITLE
[feat] 목록 페이지 & 탭 기능 연결

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,11 @@
 import { Suspense } from 'react';
+import NewsFeedSkeleton from '@/features/news/ui/NewsFeedSkeleton';
 import NewsList from '@/features/news/ui/NewsList';
 import TabBar from '@/features/news/ui/TabBar';
 
 export default function Home() {
   return (
-    // TODO: 스켈레톤 UI 적용하기
-    <Suspense fallback={'불러오는 중'}>
+    <Suspense fallback={<NewsFeedSkeleton />}>
       <TabBar />
       <NewsList />
     </Suspense>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,25 @@
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query';
 import { Suspense } from 'react';
 import NewsFeedSkeleton from '@/features/news/ui/NewsFeedSkeleton';
 import NewsList from '@/features/news/ui/NewsList';
 import TabBar from '@/features/news/ui/TabBar';
+import { storiesQueryOptions } from '@/shared/lib/api';
 
-export default function Home() {
+export default async function Home() {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchInfiniteQuery(storiesQueryOptions('top'));
+
   return (
-    <Suspense fallback={<NewsFeedSkeleton />}>
-      <TabBar />
-      <NewsList />
-    </Suspense>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<NewsFeedSkeleton />}>
+        <TabBar />
+        <NewsList />
+      </Suspense>
+    </HydrationBoundary>
   );
 }

--- a/src/features/news/hooks/useNewsList.ts
+++ b/src/features/news/hooks/useNewsList.ts
@@ -1,0 +1,43 @@
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { QUERY_KEYS } from '@/shared/constants/queryKey';
+import { useStories } from '@/shared/hooks/useStories';
+import type { StoryTab } from '@/shared/types/hackerNews';
+
+export const useNewsList = () => {
+  const searchParams = useSearchParams();
+  const tab = (
+    searchParams.get('tab') ?? QUERY_KEYS.top
+  ).toLowerCase() as StoryTab;
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
+    useStories(tab);
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  return {
+    stories: data?.pages.flat() ?? [],
+    isPending,
+    isFetchingNextPage,
+    sentinelRef,
+  };
+};

--- a/src/features/news/hooks/useTabBar.ts
+++ b/src/features/news/hooks/useTabBar.ts
@@ -1,0 +1,44 @@
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { useRef } from 'react';
+
+const TABS = ['Top', 'New', 'Best'] as const;
+export type Tab = (typeof TABS)[number];
+
+export const useTabBar = () => {
+  const searchParams = useSearchParams();
+  const activeTab = (searchParams.get('tab') as Tab) ?? 'Top';
+  const router = useRouter();
+  const pathname = usePathname();
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const handleTabClick = (tab: Tab) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('tab', tab);
+    router.push(`${pathname}?${params.toString()}`);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
+    let nextIndex: number | null = null;
+
+    if (e.key === 'ArrowRight') {
+      nextIndex = (index + 1) % TABS.length;
+    }
+    if (e.key === 'ArrowLeft') {
+      nextIndex = (index - 1 + TABS.length) % TABS.length;
+    }
+    if (e.key === 'Home') {
+      nextIndex = 0;
+    }
+    if (e.key === 'End') {
+      nextIndex = TABS.length - 1;
+    }
+
+    if (nextIndex !== null) {
+      e.preventDefault();
+      handleTabClick(TABS[nextIndex]);
+      tabRefs.current[nextIndex]?.focus();
+    }
+  };
+
+  return { TABS, activeTab, tabRefs, handleTabClick, handleKeyDown };
+};

--- a/src/features/news/ui/NewsCard.tsx
+++ b/src/features/news/ui/NewsCard.tsx
@@ -5,9 +5,10 @@ import { formatDate, toISODate } from '@/shared/utils/time';
 
 interface NewsCardProps {
   item: HackerNewsItem;
+  preload?: boolean;
 }
 
-export default function NewsCard({ item }: NewsCardProps) {
+export default function NewsCard({ item, preload = false }: NewsCardProps) {
   const { id, title, by, time } = item;
 
   return (
@@ -22,6 +23,7 @@ export default function NewsCard({ item }: NewsCardProps) {
             alt={title}
             fill
             sizes='(min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw'
+            preload={preload}
             className='rounded-lg object-cover'
           />
         </div>

--- a/src/features/news/ui/NewsCard.tsx
+++ b/src/features/news/ui/NewsCard.tsx
@@ -11,18 +11,20 @@ export default function NewsCard({ item }: NewsCardProps) {
   const { id, title, by, time } = item;
 
   return (
-    <article className='w-full rounded-2xl border border-gray-200'>
+    <article className='h-[158px] w-full rounded-2xl border border-gray-200'>
       <Link
         href={`/story/${id}`}
         aria-label={`${title}, 작성자 ${by}, ${formatDate(time)}`}
-        className='flex gap-4 p-6'>
-        <Image
-          src={`https://picsum.photos/seed/${id}/300/200`}
-          alt={title}
-          width={102}
-          height={108}
-          className='shrink-0 rounded-lg bg-gray-200 object-cover'
-        />
+        className='flex h-full gap-4 p-6'>
+        <div className='relative h-full w-[102px] shrink-0'>
+          <Image
+            src={`https://picsum.photos/seed/${id}/300/200`}
+            alt={title}
+            fill
+            sizes='(min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw'
+            className='rounded-lg object-cover'
+          />
+        </div>
         <div className='flex flex-col justify-center gap-2'>
           <h2 className='line-clamp-2 text-base font-bold text-gray-900'>
             {title}

--- a/src/features/news/ui/NewsFeedSkeleton.tsx
+++ b/src/features/news/ui/NewsFeedSkeleton.tsx
@@ -1,0 +1,18 @@
+import { PAGE_SIZE } from '@/shared/constants/pageSize';
+import SkeletonCard from './SkeletonCard';
+import SkeletonTabBar from './SkeletonTabBar';
+
+export default function NewsFeedSkeleton() {
+  return (
+    <>
+      <SkeletonTabBar />
+      <ul className='mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3'>
+        {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+          <li key={i}>
+            <SkeletonCard />
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/src/features/news/ui/NewsList.tsx
+++ b/src/features/news/ui/NewsList.tsx
@@ -1,55 +1,31 @@
-import type { HackerNewsItem } from '@/shared/types/hackerNews';
-import NewsCard from './NewsCard';
+'use client';
 
-// TODO: 실제 데이터 연동 시 제거
-const DUMMY_LIST: HackerNewsItem[] = [
-  {
-    id: 1,
-    title: 'OpenAI releases GPT-5 with multimodal reasoning',
-    by: 'aaa',
-    time: 1746230400,
-    score: 842,
-  },
-  {
-    id: 2,
-    title: 'Anthropic announces Claude 4 with extended context window',
-    by: 'bbb',
-    time: 1746144000,
-    score: 631,
-  },
-  {
-    id: 3,
-    title: 'Google DeepMind publishes new reinforcement learning paper',
-    by: 'ccc',
-    time: 1746057600,
-    score: 512,
-  },
-  {
-    id: 4,
-    title: 'Meta open-sources its latest LLaMA model weights',
-    by: 'ddd',
-    time: 1745971200,
-    score: 478,
-  },
-  {
-    id: 5,
-    title: 'Rust becomes the most-loved language for the ninth year in a row',
-    by: 'eee',
-    time: 1745884800,
-    score: 390,
-  },
-];
+import { PAGE_SIZE } from '@/shared/constants/pageSize';
+import { useNewsList } from '../hooks/useNewsList';
+import NewsCard from './NewsCard';
+import SkeletonCard from './SkeletonCard';
 
 export default function NewsList() {
+  const { stories, isPending, isFetchingNextPage, sentinelRef } = useNewsList();
+
   return (
-    <ul
-      className='mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3'
-      aria-label='뉴스 목록'>
-      {DUMMY_LIST.map((item) => (
-        <li key={item.id}>
-          <NewsCard item={item} />
-        </li>
-      ))}
-    </ul>
+    <>
+      <ul
+        className='mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3'
+        aria-label='뉴스 목록'>
+        {stories.map((item) => (
+          <li key={item.id}>
+            <NewsCard item={item} />
+          </li>
+        ))}
+        {(isPending || isFetchingNextPage) &&
+          Array.from({ length: PAGE_SIZE }).map((_, i) => (
+            <li key={`skeleton-${i}`}>
+              <SkeletonCard />
+            </li>
+          ))}
+      </ul>
+      <div ref={sentinelRef} className='h-1' />
+    </>
   );
 }

--- a/src/features/news/ui/NewsList.tsx
+++ b/src/features/news/ui/NewsList.tsx
@@ -13,9 +13,9 @@ export default function NewsList() {
       <ul
         className='mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3'
         aria-label='뉴스 목록'>
-        {stories.map((item) => (
+        {stories.map((item, index) => (
           <li key={item.id}>
-            <NewsCard item={item} />
+            <NewsCard item={item} preload={index < 3} />
           </li>
         ))}
         {(isPending || isFetchingNextPage) &&

--- a/src/features/news/ui/SkeletonCard.tsx
+++ b/src/features/news/ui/SkeletonCard.tsx
@@ -1,11 +1,13 @@
+import SkeletonBox from '@/shared/ui/SkeletonBox';
+
 export default function SkeletonCard() {
   return (
     <div className='flex h-[158px] w-full animate-pulse gap-4 overflow-hidden rounded-2xl border border-gray-200 p-6'>
-      <div className='h-full w-[102px] shrink-0 rounded-sm bg-gray-200' />
+      <SkeletonBox className='h-full w-[102px] shrink-0' />
       <div className='flex flex-1 flex-col justify-center gap-2'>
-        <div className='h-6 w-4/5 rounded bg-gray-200' />
-        <div className='h-5.5 w-1/3 rounded bg-gray-200' />
-        <div className='h-5.5 w-1/4 rounded bg-gray-200' />
+        <SkeletonBox className='h-6 w-4/5' />
+        <SkeletonBox className='h-4 w-1/3' />
+        <SkeletonBox className='h-4 w-1/4' />
       </div>
     </div>
   );

--- a/src/features/news/ui/SkeletonTabBar.tsx
+++ b/src/features/news/ui/SkeletonTabBar.tsx
@@ -1,0 +1,15 @@
+import SkeletonBox from '@/shared/ui/SkeletonBox';
+
+const TAB_COUNT = 3;
+
+export default function SkeletonTabBar() {
+  return (
+    <div className='sticky top-18 z-10 flex w-full animate-pulse border-b border-gray-200 bg-white'>
+      {Array.from({ length: TAB_COUNT }).map((_, i) => (
+        <div key={i} className='flex flex-1 justify-center py-3'>
+          <SkeletonBox className='h-4 w-8' />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/news/ui/TabBar.tsx
+++ b/src/features/news/ui/TabBar.tsx
@@ -1,48 +1,11 @@
 'use client';
 
-import { useRouter, useSearchParams, usePathname } from 'next/navigation';
-import { useRef } from 'react';
 import { cn } from '@/shared/lib/cn';
-
-const TABS = ['Top', 'New', 'Best'] as const;
-type Tab = (typeof TABS)[number];
+import { useTabBar } from '../hooks/useTabBar';
 
 export default function TabBar() {
-  const searchParams = useSearchParams();
-  const activeTab = (searchParams.get('tab') as Tab) ?? 'Top';
-  const router = useRouter();
-  const pathname = usePathname();
-  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
-
-  const handleTabClick = (tab: Tab) => {
-    // TODO: 탭 전환에 따른 뉴스 목록 필터링 연결
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('tab', tab);
-    router.push(`${pathname}?${params.toString()}`);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
-    let nextIndex: number | null = null;
-
-    if (e.key === 'ArrowRight') {
-      nextIndex = (index + 1) % TABS.length;
-    }
-    if (e.key === 'ArrowLeft') {
-      nextIndex = (index - 1 + TABS.length) % TABS.length;
-    }
-    if (e.key === 'Home') {
-      nextIndex = 0;
-    }
-    if (e.key === 'End') {
-      nextIndex = TABS.length - 1;
-    }
-
-    if (nextIndex !== null) {
-      e.preventDefault();
-      handleTabClick(TABS[nextIndex]);
-      tabRefs.current[nextIndex]?.focus();
-    }
-  };
+  const { TABS, activeTab, tabRefs, handleTabClick, handleKeyDown } =
+    useTabBar();
 
   return (
     <div

--- a/src/shared/constants/queryKey.ts
+++ b/src/shared/constants/queryKey.ts
@@ -1,0 +1,4 @@
+export const QUERY_KEYS = {
+  stories: 'stories',
+  top: 'top',
+} as const;

--- a/src/shared/hooks/useStories.ts
+++ b/src/shared/hooks/useStories.ts
@@ -18,6 +18,8 @@ export const useStories = (tab: StoryTab) => {
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) =>
       lastPage.length < PAGE_SIZE ? undefined : allPages.length,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
     throwOnError: true,
   });
 };

--- a/src/shared/hooks/useStories.ts
+++ b/src/shared/hooks/useStories.ts
@@ -1,21 +1,11 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { PAGE_SIZE } from '@/shared/constants/pageSize';
-import { QUERY_KEYS } from '@/shared/constants/queryKey';
-import { fetchStory, fetchStoryIds } from '@/shared/lib/api';
+import { storiesQueryOptions } from '@/shared/lib/api';
 import { StoryTab } from '@/shared/types/hackerNews';
 
 export const useStories = (tab: StoryTab) => {
   return useInfiniteQuery({
-    queryKey: [QUERY_KEYS.stories, tab],
-    queryFn: async ({ pageParam }) => {
-      const allIds = await fetchStoryIds(tab);
-      const pageIds = allIds.slice(
-        pageParam * PAGE_SIZE,
-        (pageParam + 1) * PAGE_SIZE,
-      );
-      return Promise.all(pageIds.map(fetchStory));
-    },
-    initialPageParam: 0,
+    ...storiesQueryOptions(tab),
     getNextPageParam: (lastPage, allPages) =>
       lastPage.length < PAGE_SIZE ? undefined : allPages.length,
     staleTime: 5 * 60 * 1000,

--- a/src/shared/hooks/useStories.ts
+++ b/src/shared/hooks/useStories.ts
@@ -1,0 +1,23 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { PAGE_SIZE } from '@/shared/constants/pageSize';
+import { QUERY_KEYS } from '@/shared/constants/queryKey';
+import { fetchStory, fetchStoryIds } from '@/shared/lib/api';
+import { StoryTab } from '@/shared/types/hackerNews';
+
+export const useStories = (tab: StoryTab) => {
+  return useInfiniteQuery({
+    queryKey: [QUERY_KEYS.stories, tab],
+    queryFn: async ({ pageParam }) => {
+      const allIds = await fetchStoryIds(tab);
+      const pageIds = allIds.slice(
+        pageParam * PAGE_SIZE,
+        (pageParam + 1) * PAGE_SIZE,
+      );
+      return Promise.all(pageIds.map(fetchStory));
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length < PAGE_SIZE ? undefined : allPages.length,
+    throwOnError: true,
+  });
+};

--- a/src/shared/lib/api.ts
+++ b/src/shared/lib/api.ts
@@ -1,3 +1,5 @@
+import { PAGE_SIZE } from '@/shared/constants/pageSize';
+import { QUERY_KEYS } from '@/shared/constants/queryKey';
 import { HackerNewsItem, StoryTab } from '@/shared/types/hackerNews';
 
 const BASE_URL = 'https://hacker-news.firebaseio.com/v0';
@@ -17,3 +19,16 @@ export const fetchStory = async (id: number): Promise<HackerNewsItem> => {
   }
   return res.json();
 };
+
+export const storiesQueryOptions = (tab: StoryTab) => ({
+  queryKey: [QUERY_KEYS.stories, tab],
+  queryFn: async ({ pageParam }: { pageParam: number }) => {
+    const allIds = await fetchStoryIds(tab);
+    const pageIds = allIds.slice(
+      pageParam * PAGE_SIZE,
+      (pageParam + 1) * PAGE_SIZE,
+    );
+    return Promise.all(pageIds.map(fetchStory));
+  },
+  initialPageParam: 0,
+});

--- a/src/shared/ui/SkeletonBox.tsx
+++ b/src/shared/ui/SkeletonBox.tsx
@@ -1,0 +1,5 @@
+import { cn } from '@/shared/lib/cn';
+
+export default function SkeletonBox({ className }: { className?: string }) {
+  return <div className={cn('rounded bg-gray-200', className)} />;
+}

--- a/src/shared/ui/SkeletonCard.tsx
+++ b/src/shared/ui/SkeletonCard.tsx
@@ -1,6 +1,6 @@
 export default function SkeletonCard() {
   return (
-    <div className='flex h-[128px] w-full animate-pulse gap-6 overflow-hidden rounded-xl border border-gray-200 p-6'>
+    <div className='flex h-[158px] w-full animate-pulse gap-4 overflow-hidden rounded-2xl border border-gray-200 p-6'>
       <div className='h-full w-[102px] shrink-0 rounded-sm bg-gray-200' />
       <div className='flex flex-1 flex-col justify-center gap-2'>
         <div className='h-6 w-4/5 rounded bg-gray-200' />


### PR DESCRIPTION
## 📌 PR 개요

Hacker News 스토리 목록 피드를 구현합니다. TanStack Query 기반의 무한 스크롤, 스켈레톤 UI, 서버 사이드 prefetch를 통해 로딩 경험과 성능을 최적화했습니다.

## 🔍 관련 이슈

Closes #6

## 🔧 PR 유형

- [x] ✨ feat (새로운 기능)
- [x] ♻️ refactor (리팩토링)

## ✨ 변경 사항

### 데이터 패칭 & 캐싱

- `src/shared/lib/api.ts` — `storiesQueryOptions` 공통 쿼리 옵션 팩토리 함수 분리. `useStories`와 서버 사이드 `prefetchInfiniteQuery` 양쪽에서 동일 옵션을 재사용할 수 있도록 추출
- `src/shared/constants/queryKey.ts` — `QUERY_KEYS` 상수 정의로 쿼리 키 문자열 중앙 관리
- `src/shared/hooks/useStories.ts` — `useInfiniteQuery` 기반 훅 구현. `staleTime: 5분`, `gcTime: 10분` 설정으로 탭 전환 시 불필요한 재요청 방지
- `src/app/page.tsx` — 서버 컴포넌트에서 `prefetchInfiniteQuery`로 최초 top 스토리를 SSR에서 미리 적재하고 `HydrationBoundary`로 클라이언트에 전달

### 무한 스크롤 & 뉴스 목록

- `src/features/news/hooks/useNewsList.ts` — `IntersectionObserver`를 활용한 무한 스크롤 구현. 센티널 요소가 뷰포트에 진입하면 `fetchNextPage` 호출
- `src/features/news/ui/NewsList.tsx` — 뉴스 카드 그리드 렌더링. 로딩 중일 때 `SkeletonCard`를 인라인으로 추가해 레이아웃 시프트 방지
- `src/features/news/ui/NewsCard.tsx` — `preload` prop 추가. 첫 3개 카드에만 이미지 preload를 적용해 LCP 개선

### 탭 UI & 리팩토링

- `src/features/news/hooks/useTabBar.ts` — `TabBar` 컴포넌트의 라우팅·키보드 탐색 로직을 훅으로 분리 (`ArrowLeft`, `ArrowRight`, `Home`, `End` 키 지원)
- `src/features/news/ui/TabBar.tsx` — WAI-ARIA `role="tablist"` / `role="tab"` 적용, `aria-selected`·`tabIndex` 관리

### 스켈레톤 UI

- `src/shared/ui/SkeletonBox.tsx` — 스켈레톤 기본 블록 원자 컴포넌트 (`bg-gray-200` + `rounded`)
- `src/shared/ui/SkeletonCard.tsx` — 카드 형태의 스켈레톤 (이미지 영역 + 텍스트 라인 구성)
- `src/features/news/ui/SkeletonCard.tsx` — feature 레벨 스켈레톤 카드 (실제 `NewsCard` 레이아웃과 동일한 높이 유지)
- `src/features/news/ui/SkeletonTabBar.tsx` — 탭바 스켈레톤
- `src/features/news/ui/NewsFeedSkeleton.tsx` — `Suspense` fallback용 전체 피드 스켈레톤 (탭바 + 카드 그리드)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

- `storiesQueryOptions`를 공통 팩토리로 분리한 이유는 서버 컴포넌트의 `prefetchInfiniteQuery`와 클라이언트의 `useInfiniteQuery`가 동일한 `queryKey`·`queryFn`·`initialPageParam`을 공유해야 hydration mismatch가 발생하지 않기 때문입니다.
- 이미지 `preload`는 처음 렌더링되는 3개 카드에만 적용합니다. 전체 적용 시 오히려 대역폭 낭비로 LCP가 저하될 수 있습니다.
