### PR TITLE
[feat] 메인 리스트 가상 스크롤 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='ko' className='h-full antialiased'>
-      <body className='flex min-h-full flex-col px-4'>
+      <body className='flex min-h-full flex-col overflow-x-hidden px-4'>
         <Header />
         <div className='mx-auto w-full max-w-[1200px]'>
           <QueryProvider>{children}</QueryProvider>

--- a/src/features/news/hooks/useColumnCount.ts
+++ b/src/features/news/hooks/useColumnCount.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export const useColumnCount = (): number => {
+  const [columns, setColumns] = useState(1);
+
+  useEffect(() => {
+    const lgQuery = window.matchMedia('(min-width: 1024px)');
+    const smQuery = window.matchMedia('(min-width: 640px)');
+
+    const update = () => {
+      if (lgQuery.matches) {
+        setColumns(3);
+      } else if (smQuery.matches) {
+        setColumns(2);
+      } else {
+        setColumns(1);
+      }
+    };
+
+    update();
+    lgQuery.addEventListener('change', update);
+    smQuery.addEventListener('change', update);
+
+    return () => {
+      lgQuery.removeEventListener('change', update);
+      smQuery.removeEventListener('change', update);
+    };
+  }, []);
+
+  return columns;
+};

--- a/src/features/news/hooks/useNewsList.ts
+++ b/src/features/news/hooks/useNewsList.ts
@@ -1,5 +1,4 @@
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useRef } from 'react';
 import { QUERY_KEYS } from '@/shared/constants/queryKey';
 import { useStories } from '@/shared/hooks/useStories';
 import type { StoryTab } from '@/shared/types/hackerNews';
@@ -13,31 +12,11 @@ export const useNewsList = () => {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
     useStories(tab);
 
-  const sentinelRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
-          fetchNextPage();
-        }
-      },
-      { threshold: 0.1 },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
-
   return {
     stories: data?.pages.flat() ?? [],
     isPending,
     isFetchingNextPage,
-    sentinelRef,
+    fetchNextPage,
+    hasNextPage,
   };
 };

--- a/src/features/news/hooks/useNewsVirtualizer.ts
+++ b/src/features/news/hooks/useNewsVirtualizer.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useWindowVirtualizer } from '@tanstack/react-virtual';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useColumnCount } from './useColumnCount';
+import { useNewsList } from './useNewsList';
+
+const CARD_HEIGHT = 182;
+
+export const useNewsVirtualizer = () => {
+  const { stories, isPending, isFetchingNextPage, fetchNextPage, hasNextPage } =
+    useNewsList();
+  const columns = useColumnCount();
+
+  const listRef = useRef<HTMLDivElement>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  useLayoutEffect(() => {
+    if (!listRef.current) {
+      return;
+    }
+    setScrollMargin(listRef.current.offsetTop ?? 0);
+  }, []);
+
+  const rowCount = Math.ceil(stories.length / columns);
+
+  const virtualizer = useWindowVirtualizer({
+    count: hasNextPage ? rowCount + 1 : rowCount,
+    estimateSize: () => CARD_HEIGHT,
+    scrollMargin,
+    measureElement: (el) => el.getBoundingClientRect().height,
+    overscan: 3,
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  useEffect(() => {
+    const lastItem = virtualItems[virtualItems.length - 1];
+    if (!lastItem) {
+      return;
+    }
+    if (lastItem.index >= rowCount - 1 && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [rowCount, virtualItems, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return {
+    listRef,
+    virtualizer,
+    virtualItems,
+    scrollMargin,
+    rowCount,
+    columns,
+    stories,
+    isPending,
+    isFetchingNextPage,
+  };
+};

--- a/src/features/news/ui/NewsCard.tsx
+++ b/src/features/news/ui/NewsCard.tsx
@@ -24,6 +24,8 @@ export default function NewsCard({ item, preload = false }: NewsCardProps) {
             fill
             sizes='(min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw'
             preload={preload}
+            placeholder='blur'
+            blurDataURL='data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw=='
             className='rounded-lg object-cover'
           />
         </div>

--- a/src/features/news/ui/NewsList.tsx
+++ b/src/features/news/ui/NewsList.tsx
@@ -1,31 +1,111 @@
 'use client';
 
 import { PAGE_SIZE } from '@/shared/constants/pageSize';
-import { useNewsList } from '../hooks/useNewsList';
+import type { HackerNewsItem } from '@/shared/types/hackerNews';
+import { useNewsVirtualizer } from '../hooks/useNewsVirtualizer';
 import NewsCard from './NewsCard';
 import SkeletonCard from './SkeletonCard';
 
+type RowGridProps = {
+  columns: number;
+  children: React.ReactNode;
+};
+
+function RowGrid({ columns, children }: RowGridProps) {
+  return (
+    <div
+      className='grid gap-6'
+      style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}>
+      {children}
+    </div>
+  );
+}
+
+type NewsRowProps = {
+  rowStories: HackerNewsItem[];
+  preload: boolean;
+};
+
+function NewsRow({ rowStories, preload }: NewsRowProps) {
+  return rowStories.map((item) => (
+    <div key={item.id} role='listitem'>
+      <NewsCard item={item} preload={preload} />
+    </div>
+  ));
+}
+
+type SkeletonRowProps = {
+  columns: number;
+};
+
+function SkeletonRow({ columns }: SkeletonRowProps) {
+  return Array.from({ length: columns }).map((_, i) => (
+    <SkeletonCard key={i} />
+  ));
+}
+
 export default function NewsList() {
-  const { stories, isPending, isFetchingNextPage, sentinelRef } = useNewsList();
+  const {
+    listRef,
+    virtualizer,
+    virtualItems,
+    scrollMargin,
+    rowCount,
+    columns,
+    stories,
+    isPending,
+  } = useNewsVirtualizer();
+
+  if (isPending) {
+    const skeletonRowCount = Math.ceil(PAGE_SIZE / columns);
+    return (
+      <div ref={listRef} className='mt-8 flex flex-col gap-6'>
+        {Array.from({ length: skeletonRowCount }).map((_, i) => (
+          <RowGrid key={i} columns={columns}>
+            <SkeletonRow columns={columns} />
+          </RowGrid>
+        ))}
+      </div>
+    );
+  }
 
   return (
-    <>
-      <ul
-        className='mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3'
-        aria-label='뉴스 목록'>
-        {stories.map((item, index) => (
-          <li key={item.id}>
-            <NewsCard item={item} preload={index < 3} />
-          </li>
-        ))}
-        {(isPending || isFetchingNextPage) &&
-          Array.from({ length: PAGE_SIZE }).map((_, i) => (
-            <li key={`skeleton-${i}`}>
-              <SkeletonCard />
-            </li>
-          ))}
-      </ul>
-      <div ref={sentinelRef} className='h-1' />
-    </>
+    <div ref={listRef} className='mt-8'>
+      <div
+        role='list'
+        aria-label='뉴스 목록'
+        className='relative'
+        style={{ height: virtualizer.getTotalSize() }}>
+        {virtualItems.map((virtualRow) => {
+          const isLoaderRow = virtualRow.index > rowCount - 1;
+          const rowStories = stories.slice(
+            virtualRow.index * columns,
+            (virtualRow.index + 1) * columns,
+          );
+
+          return (
+            <div
+              key={virtualRow.key}
+              data-index={virtualRow.index}
+              ref={virtualizer.measureElement}
+              className='absolute top-0 left-0 w-full pb-6'
+              style={{
+                transform: `translateY(${virtualRow.start - scrollMargin}px)`,
+              }}>
+              <RowGrid columns={columns}>
+                {isLoaderRow ? (
+                  <SkeletonRow columns={columns} />
+                ) : (
+                  <NewsRow
+                    rowStories={rowStories}
+                    preload={virtualRow.index === 0}
+                  />
+                )}
+              </RowGrid>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/src/shared/providers/QueryProvider.tsx
+++ b/src/shared/providers/QueryProvider.tsx
@@ -12,7 +12,11 @@ const ReactQueryDevtools =
       )
     : () => null;
 
-const QueryProvider = ({ children }: { children: React.ReactNode }) => {
+export default function QueryProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -32,6 +36,4 @@ const QueryProvider = ({ children }: { children: React.ReactNode }) => {
       </Suspense>
     </QueryClientProvider>
   );
-};
-
-export default QueryProvider;
+}


### PR DESCRIPTION
## 📌 PR 개요

`useWindowVirtualizer`를 적용해 뉴스 목록에 가상 스크롤을 구현했습니다. 기존 무한 스크롤의 sentinel 방식을 index 기반 트리거로 전환하고, 반응형 그리드 열 수를 미디어 쿼리로 관리합니다.

## 🔍 관련 이슈

Closes #11

## 🔧 PR 유형

- [x] ✨ feat (새로운 기능)
- [x] 🐛 fix (버그 수정)
- [x] ♻️ refactor (리팩토링)

## ✨ 변경 사항

### 가상 스크롤 핵심 구현

- `useNewsVirtualizer.ts` (신규): 가상화 관련 로직을 전담하는 훅. `useWindowVirtualizer` 설정, `scrollMargin` 계산(`useLayoutEffect`), index 기반 `fetchNextPage` 트리거를 포함. `NewsList`는 렌더링만 담당하도록 관심사를 분리
- `useColumnCount.ts` (신규): `window.matchMedia`로 반응형 열 수를 관리하는 훅. resize 이벤트 대신 브레이크포인트 변경 시에만 발화해 불필요한 연산 없음. SSR 대응을 위해 초기값 1로 선언 후 `useEffect`에서 실행
- `useNewsList.ts`: `sentinelRef`, `IntersectionObserver` 제거. 기존 sentinel 방식 트리거를 `useNewsVirtualizer` 내부의 index 기반 방식으로 대체

### UI 렌더링 구조 개편

- `NewsList.tsx`: `RowGrid` / `NewsRow` / `SkeletonRow` 서브 컴포넌트로 분리. 가상 컨테이너는 `position: relative; height: getTotalSize()`로 전체 스크롤 높이를 확보하고, 각 행은 `position: absolute; transform: translateY(row.start - scrollMargin)`으로 정확한 위치에 배치. 초기 로딩 시 `PAGE_SIZE / columns` 행만큼 스켈레톤 표시

### 버그 수정 및 UX 개선

- `layout.tsx`: `body`에 `overflow-x-hidden` 추가. 탭바의 `after:w-screen` 요소가 max-width 컨테이너 밖으로 넘쳐 발생하던 가로 스크롤 제거
- `NewsCard.tsx`: `Image`에 `placeholder="blur"` + `blurDataURL`(base64 회색 1×1 GIF) 추가. 이미지 로드 전 빈 공간 대신 흐릿한 플레이스홀더가 표시되어 깜빡임 개선
- `QueryProvider.tsx`: `const` 화살표 함수에서 `function` 선언으로 변경 (컴포넌트 선언 컨벤션 통일)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

- `useWindowVirtualizer`는 window를 스크롤 컨테이너로 자동 사용하므로 별도의 고정 높이 컨테이너가 불필요
- index 기반 트리거(`lastItem.index >= rowCount - 1`)는 TanStack 공식 권장 방식으로, 행(row) 단위 가상화에서 `rowCount`와 비교해야 올바르게 동작 (`stories.length`와 비교하면 트리거되지 않음)
- `useColumnCount`의 초기값 `1`로 인해 SSR → 클라이언트 하이드레이션 직후 열 수가 업데이트되며 레이아웃이 조정됨
