### PR TITLE
[feat] 404 페이지

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+import Button from '@/shared/ui/Button';
+
+export default function NotFound() {
+  return (
+    <div className='flex flex-col items-center justify-center py-32 text-center'>
+      <p className='text-8xl font-bold text-primary'>404</p>
+      <p className='mt-4 text-sm text-gray-500'>페이지를 찾을 수 없습니다.</p>
+      <Button as='link' href='/' className='mt-8'>
+        메인으로 이동
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 PR 개요

존재하지 않는 경로 접근 시 표시되는 404 페이지를 구현합니다. Next.js 기본 404 페이지 대신 프로젝트 스타일에 맞는 `not-found.tsx`를 추가해 일관된 사용자 경험을 제공합니다.

## 🔍 관련 이슈

Closes #12

## 🔧 PR 유형

- [x] ✨ feat (새로운 기능)

## ✨ 변경 사항

### 404 페이지 추가

- `src/app/not-found.tsx` 신규 생성
  - 큰 **404** 텍스트(`text-8xl`)로 오류 상황을 직관적으로 전달
  - "페이지를 찾을 수 없습니다." 안내 메시지 표시
  - 기존 `Button` 컴포넌트를 `as='link'`로 재사용해 메인(`/`)으로 이동하는 링크 버튼 제공
  - `error.tsx`와 동일한 레이아웃 구조(`py-32`, `text-center`, `flex-col items-center`) 사용으로 디자인 일관성 유지

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

- `src/app/not-found.tsx` 위치에 두면 Next.js가 전체 앱의 404 fallback으로 자동 적용함
- 상세 페이지 등에서 `notFound()`를 호출하는 케이스도 이 파일로 처리됨
