### PR TITLE
[feat] 상세 페이지 API 연동 및 로딩 상태

### DIFF
--- a/src/app/story/[id]/loading.tsx
+++ b/src/app/story/[id]/loading.tsx
@@ -1,0 +1,48 @@
+import SkeletonBox from '@/shared/ui/SkeletonBox';
+
+export default function DetailStoryLoading() {
+  return (
+    <main className='py-8'>
+      <nav aria-label='페이지 탐색' className='mb-8'>
+        <SkeletonBox className='h-5 w-32' />
+      </nav>
+
+      <article>
+        <header className='mb-8 border-b border-gray-200 pb-8'>
+          <SkeletonBox className='mb-6 h-[30px] w-full' />
+
+          <dl className='flex flex-col gap-3'>
+            <div className='flex items-center gap-3'>
+              <dt className='w-14 shrink-0 text-sm font-semibold text-gray-500'>
+                작성자
+              </dt>
+              <dd>
+                <SkeletonBox className='h-6 w-24' />
+              </dd>
+            </div>
+            <div className='flex items-center gap-3'>
+              <dt className='w-14 shrink-0 text-sm font-semibold text-gray-500'>
+                점수
+              </dt>
+              <dd>
+                <SkeletonBox className='h-5 w-12 rounded-full' />
+              </dd>
+            </div>
+            <div className='flex items-center gap-3'>
+              <dt className='w-14 shrink-0 text-sm font-semibold text-gray-500'>
+                작성일
+              </dt>
+              <dd>
+                <SkeletonBox className='h-6 w-32' />
+              </dd>
+            </div>
+          </dl>
+        </header>
+
+        <section>
+          <SkeletonBox className='h-10 w-30 rounded-lg' />
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/src/app/story/[id]/page.tsx
+++ b/src/app/story/[id]/page.tsx
@@ -1,23 +1,24 @@
 import Link from 'next/link';
+import { notFound } from 'next/navigation';
 import ArrowLeftIcon from '@/shared/assets/icons/arrow-left.svg';
 import ExternalLinkIcon from '@/shared/assets/icons/external-link.svg';
-import type { HackerNewsItem } from '@/shared/types/hackerNews';
+import { fetchStory } from '@/shared/lib/api';
 import Button from '@/shared/ui/Button';
 import { formatDate, toISODate } from '@/shared/utils/time';
 
-// TODO: api 연동 시 제거
-const dummyStory: HackerNewsItem = {
-  id: 43900226,
-  title:
-    'Show HN: I built an open-source AI-powered news aggregator in Next.js',
-  by: 'johndoe',
-  time: 1746316800,
-  score: 342,
-  url: 'https://example.com/my-project',
-};
+export default async function DetailStory({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const story = await fetchStory(Number(id));
 
-export default function DetailStory() {
-  const { title, by, time, score, url } = dummyStory;
+  if (!story) {
+    notFound();
+  }
+
+  const { title, by, time, score, url } = story;
 
   return (
     <main className='py-8'>

--- a/src/features/news/ui/SkeletonCard.tsx
+++ b/src/features/news/ui/SkeletonCard.tsx
@@ -2,7 +2,7 @@ import SkeletonBox from '@/shared/ui/SkeletonBox';
 
 export default function SkeletonCard() {
   return (
-    <div className='flex h-[158px] w-full animate-pulse gap-4 overflow-hidden rounded-2xl border border-gray-200 p-6'>
+    <div className='flex h-[158px] w-full gap-4 overflow-hidden rounded-2xl border border-gray-200 p-6'>
       <SkeletonBox className='h-full w-[102px] shrink-0' />
       <div className='flex flex-1 flex-col justify-center gap-2'>
         <SkeletonBox className='h-6 w-4/5' />

--- a/src/features/news/ui/SkeletonTabBar.tsx
+++ b/src/features/news/ui/SkeletonTabBar.tsx
@@ -4,7 +4,7 @@ const TAB_COUNT = 3;
 
 export default function SkeletonTabBar() {
   return (
-    <div className='sticky top-18 z-10 flex w-full animate-pulse border-b border-gray-200 bg-white'>
+    <div className='sticky top-18 z-10 flex w-full border-b border-gray-200 bg-white'>
       {Array.from({ length: TAB_COUNT }).map((_, i) => (
         <div key={i} className='flex flex-1 justify-center py-3'>
           <SkeletonBox className='h-4 w-8' />

--- a/src/shared/lib/api.ts
+++ b/src/shared/lib/api.ts
@@ -7,7 +7,7 @@ const BASE_URL = 'https://hacker-news.firebaseio.com/v0';
 export const fetchStoryIds = async (tab: StoryTab): Promise<number[]> => {
   const res = await fetch(`${BASE_URL}/${tab}stories.json`);
   if (!res.ok) {
-    throw new Error(`Failed to fetch ${tab} stories`);
+    throw new Error(`${tab} 스토리 목록을 불러오지 못했습니다`);
   }
   return res.json();
 };
@@ -15,7 +15,7 @@ export const fetchStoryIds = async (tab: StoryTab): Promise<number[]> => {
 export const fetchStory = async (id: number): Promise<HackerNewsItem> => {
   const res = await fetch(`${BASE_URL}/item/${id}.json`);
   if (!res.ok) {
-    throw new Error(`Failed to fetch story ${id}`);
+    throw new Error(`스토리(${id})를 불러오지 못했습니다`);
   }
   return res.json();
 };

--- a/src/shared/ui/SkeletonBox.tsx
+++ b/src/shared/ui/SkeletonBox.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/shared/lib/cn';
 
 export default function SkeletonBox({ className }: { className?: string }) {
-  return <div className={cn('rounded bg-gray-200', className)} />;
+  return <div className={cn('animate-pulse rounded bg-gray-200', className)} />;
 }


### PR DESCRIPTION
## 📌 PR 개요

상세 페이지(`/story/[id]`)에 하드코딩된 더미 데이터를 제거하고 Hacker News API와 실제 연동하며, 데이터 로딩 중 표시할 스켈레톤 UI를 추가합니다.

## 🔍 관련 이슈

Closes #13

## 🔧 PR 유형

- [x] ✨ feat (새로운 기능)
- [x] ♻️ refactor (리팩토링)

## ✨ 변경 사항

### 상세 페이지 API 연동 (`src/app/story/[id]/page.tsx`)

- 하드코딩된 더미 데이터 및 TODO 주석 제거
- 컴포넌트를 `async` Server Component로 변경
- Next.js 15의 async `params`를 `await`으로 언래핑 후 `fetchStory(id)` 호출
- 스토리가 존재하지 않을 경우 `notFound()` 호출로 404 처리

### 로딩 스켈레톤 추가 (`src/app/story/[id]/loading.tsx`)

- 상세 페이지 레이아웃과 동일한 구조의 스켈레톤 신규 작성
- Next.js `loading.tsx`가 자동으로 Suspense boundary를 생성하므로, 페이지 컴포넌트가 데이터를 fetch하는 동안 스켈레톤이 즉시 스트리밍됨
- 각 요소의 높이·너비를 실제 콘텐츠 크기에 맞게 조정하여 레이아웃 시프트(CLS) 최소화
  - 뒤로가기 링크, 제목, 작성자/점수/작성일 행, 원문 보기 버튼

### `SkeletonBox` 애니메이션 내장 (`src/shared/ui/SkeletonBox.tsx`)

- `animate-pulse`를 컴포넌트 기본값으로 이동
- 기존에 부모 래퍼에 `animate-pulse`를 선언하던 `SkeletonCard`, `SkeletonTabBar`에서 해당 클래스 제거

### API 에러 메시지 한국어화 (`src/shared/lib/api.ts`)

- `error.tsx`가 `error.message`를 그대로 노출하는 구조이므로, 영문 에러 메시지를 한국어로 변경
  - `"Failed to fetch {tab} stories"` → `"{tab} 스토리 목록을 불러오지 못했습니다"`
  - `"Failed to fetch story {id}"` → `"스토리({id})를 불러오지 못했습니다"`

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

- `loading.tsx`는 같은 라우트 세그먼트의 `page.tsx`를 자동으로 Suspense로 감싸므로, 별도 Suspense boundary 추가는 불필요합니다.
- `async` Server Component 방식을 채택한 이유: `React.use()`는 Client Component + Suspense 조합을 위한 패턴으로, Server Component에서는 `async/await`이 더 명확하고 Next.js 공식 권장 방식입니다.
