### PR TITLE
[fix] Vercel 빌드 타입 에러

### DIFF
--- a/src/shared/lib/api.ts
+++ b/src/shared/lib/api.ts
@@ -30,7 +30,8 @@ export const storiesQueryOptions = (tab: StoryTab) => ({
       pageParam * PAGE_SIZE,
       (pageParam + 1) * PAGE_SIZE,
     );
-    return Promise.all(pageIds.map(fetchStory));
+    const stories = await Promise.all(pageIds.map(fetchStory));
+    return stories.filter((s): s is HackerNewsItem => s !== null);
   },
   initialPageParam: 0,
 });


### PR DESCRIPTION
## 📌 PR 개요

`fetchStory` 반환 타입을 `HackerNewsItem | null`로 수정한 이후 발생한 Vercel 빌드 타입 에러를 수정합니다. `storiesQueryOptions`에서 null 아이템을 필터링해 `NewsRow`의 기존 타입과 호환되도록 처리합니다.

## 🔍 관련 이슈

Closes #21

## 🔧 PR 유형

- [x] 🐛 fix (버그 수정)


## ✨ 변경 사항

### null 필터링 추가 — `src/shared/lib/api.ts`

- `storiesQueryOptions`의 `queryFn`에서 `Promise.all` 결과를 타입 가드로 필터링
  ```ts
  const stories = await Promise.all(pageIds.map(fetchStory));
  return stories.filter((s): s is HackerNewsItem => s !== null);
  ```
- `fetchStory`의 반환 타입(`HackerNewsItem | null`)은 유지 — 상세 페이지의 `notFound()` 처리에 필요
- 목록에서는 삭제된 스토리(null)를 자동으로 제외하고 `HackerNewsItem[]` 반환

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음
