### PR TITLE
[refactor] 상세 페이지 — url 없는 스토리 링크 처리

### DIFF
--- a/src/app/story/[id]/page.tsx
+++ b/src/app/story/[id]/page.tsx
@@ -28,7 +28,9 @@ export default async function DetailStory({
     notFound();
   }
 
-  const { title, by, time, score, url } = story;
+  const { id: storyId, title, by, time, score, url } = story;
+  const linkUrl = url ?? `https://news.ycombinator.com/item?id=${storyId}`;
+  const linkLabel = url ? '원문 보기' : 'HN에서 보기';
 
   return (
     <main className='py-8'>
@@ -83,20 +85,18 @@ export default async function DetailStory({
           </dl>
         </header>
 
-        {url && (
-          <section aria-label='원문 링크'>
-            <Button
-              as='link'
-              href={url}
-              target='_blank'
-              rel='noopener noreferrer'
-              className='gap-2'>
-              원문 보기
-              <ExternalLinkIcon aria-hidden='true' focusable='false' />
-              <span className='sr-only'>(새 탭에서 열림)</span>
-            </Button>
-          </section>
-        )}
+        <section aria-label='원문 링크'>
+          <Button
+            as='link'
+            href={linkUrl}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='gap-2'>
+            {linkLabel}
+            <ExternalLinkIcon aria-hidden='true' focusable='false' />
+            <span className='sr-only'>(새 탭에서 열림)</span>
+          </Button>
+        </section>
       </article>
     </main>
   );


### PR DESCRIPTION
## 📌 PR 개요

상세 페이지에서 외부 URL이 없는 `Ask HN` / `Show HN` 유형 스토리에도 항상 링크 버튼이 표시되도록 fallback 처리를 추가했습니다. 아울러 README 전면 개편 및 파비콘 교체를 함께 포함합니다.

## 🔍 관련 이슈

Closes #24

## 🔧 PR 유형

- [x] ♻️ refactor (리팩토링)

## ✨ 변경 사항

### ♻️ 상세 페이지 URL fallback 처리

- `src/app/story/[id]/page.tsx`에서 `url && (...)` 조건부 렌더링 제거
- `url` 유무에 따라 `linkUrl` / `linkLabel` 두 변수로만 분기하도록 리팩토링
  - `url` 있음 → "원문 보기", 외부 링크
  - `url` 없음 → "HN에서 보기", `https://news.ycombinator.com/item?id={id}` fallback
- 버튼은 항상 렌더링되므로 `Ask HN` 등 URL 없는 스토리에서도 HN 원문으로 이동 가능
- `HackerNewsItem` 타입에 이미 `id` 필드가 포함되어 있어 타입 변경 없이 적용

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

- `url` 없는 케이스는 `top` 탭에서는 거의 발생하지 않고 `new` 탭에서 약 5% 비율로 발생
- `https://news.ycombinator.com/item?id={id}` 는 모든 HN 스토리에 항상 존재하는 고유 URL이므로 fallback으로 안전하게 사용 가능
