### PR TITLE
[refactor] LCP 개선 - 이미지 sizes 수정

### DIFF
--- a/src/features/news/ui/NewsCard.tsx
+++ b/src/features/news/ui/NewsCard.tsx
@@ -22,7 +22,7 @@ export default function NewsCard({ item, preload = false }: NewsCardProps) {
             src={`https://picsum.photos/seed/${id}/300/200`}
             alt={title}
             fill
-            sizes='(min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw'
+            sizes='102px'
             preload={preload}
             placeholder='blur'
             blurDataURL='data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw=='


### PR DESCRIPTION
## 📌 PR 개요

`NewsCard`의 `<Image sizes>` 값이 그리드 셀 비율로 잘못 설정되어 있던 것을 실제 이미지 표시 크기인 `102px`로 수정해 불필요한 이미지 다운로드를 줄이고 LCP를 개선합니다.

## 🔍 관련 이슈

Closes #26

## 🔧 PR 유형

- [x] ♻️ refactor (리팩토링)

## ✨ 변경 사항

### `NewsCard.tsx` — `sizes` 값 수정

```
- sizes='(min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw'
+ sizes='102px'
```

`sizes` 속성은 그리드 레이아웃 크기가 아닌 **이미지 엘리먼트의 실제 표시 크기**를 의미함.
카드 내 이미지 컨테이너는 항상 고정 `w-[102px]`이므로, 기존 설정은 1200px 뷰포트 기준으로 ~400px짜리 이미지를 요청하고 있었음.
`102px`로 수정하면 Next.js Image가 실제 필요한 크기의 이미지를 요청해 약 4배 이상의 데이터 절감 효과가 있음.

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

LCP 요소가 `picsum.photos` 외부 CDN 이미지이므로, `sizes` 수정 이후에도 CDN 응답 속도에 따라 Lighthouse LCP 수치는 변동될 수 있음.
첫 번째 row 이미지에는 `preload={true}`가 이미 적용되어 있어 조기 다운로드는 별도로 처리되고 있음.
