### PR TITLE
[refactor] 이미지 압축률 개선 — AVIF 포맷 + quality 조정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,8 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [{ hostname: 'picsum.photos' }],
+    formats: ['image/avif', 'image/webp'],
+    qualities: [60, 75],
   },
   turbopack: {
     rules: {

--- a/src/features/news/ui/NewsCard.tsx
+++ b/src/features/news/ui/NewsCard.tsx
@@ -22,6 +22,7 @@ export default function NewsCard({ item, preload = false }: NewsCardProps) {
             src={`https://picsum.photos/seed/${id}/300/200`}
             alt={title}
             fill
+            quality={60}
             sizes='102px'
             preload={preload}
             placeholder='blur'


### PR DESCRIPTION
## 📌 PR 개요

카드 썸네일 이미지의 압축률을 높여 LCP 개선을 도모합니다.
AVIF 포맷 활성화와 `quality` 값 조정으로 동일 화질에서 이미지 다운로드 크기를 줄입니다.

## 🔍 관련 이슈

Closes #28

## 🔧 PR 유형

- [x] ♻️ refactor (리팩토링)

## ✨ 변경 사항

### `next.config.ts` — AVIF 포맷 및 허용 quality 목록 추가

```ts
images: {
  formats: ['image/avif', 'image/webp'],  // AVIF 우선 제공, 미지원 시 WebP 폴백
  qualities: [60, 75],                    // 커스텀 quality 허용 목록 (Next.js 16 필수)
},
```

- AVIF는 WebP 대비 동일 화질에서 약 20~30% 더 작은 파일 크기를 제공
- `qualities` 배열을 명시하지 않으면 커스텀 quality 사용 시 콘솔 경고 발생

### `NewsCard.tsx` — `quality` 조정

```tsx
<Image
  quality={60}   // 기본값 75 → 60, 102px 썸네일에서 시각적 차이 없음
  sizes='102px'
  ...
/>
```

102px 고정 크기의 썸네일에서 quality 60은 육안으로 구분하기 어려운 수준이며,
파일 크기를 추가로 절감할 수 있음.

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

Lighthouse는 cold 캐시로 측정하므로 AVIF 변환 캐싱 전 첫 요청은 개선 효과가 제한적일 수 있음.
실사용 환경(warm 캐시)에서 체감 효과가 더 크게 나타남.
