### PR TITLE
[refactor] 스켈레톤 스타일 통일

### DIFF
--- a/src/features/news/ui/NewsFeedSkeleton.tsx
+++ b/src/features/news/ui/NewsFeedSkeleton.tsx
@@ -1,18 +1,11 @@
-import { PAGE_SIZE } from '@/shared/constants/pageSize';
-import SkeletonCard from './SkeletonCard';
+import SkeletonGrid from './SkeletonGrid';
 import SkeletonTabBar from './SkeletonTabBar';
 
 export default function NewsFeedSkeleton() {
   return (
     <>
       <SkeletonTabBar />
-      <ul className='mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3'>
-        {Array.from({ length: PAGE_SIZE }).map((_, i) => (
-          <li key={i}>
-            <SkeletonCard />
-          </li>
-        ))}
-      </ul>
+      <SkeletonGrid />
     </>
   );
 }

--- a/src/features/news/ui/NewsList.tsx
+++ b/src/features/news/ui/NewsList.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { PAGE_SIZE } from '@/shared/constants/pageSize';
 import type { HackerNewsItem } from '@/shared/types/hackerNews';
 import { useNewsVirtualizer } from '../hooks/useNewsVirtualizer';
 import NewsCard from './NewsCard';
 import SkeletonCard from './SkeletonCard';
+import SkeletonGrid from './SkeletonGrid';
 
 type RowGridProps = {
   columns: number;
@@ -57,14 +57,9 @@ export default function NewsList() {
   } = useNewsVirtualizer();
 
   if (isPending) {
-    const skeletonRowCount = Math.ceil(PAGE_SIZE / columns);
     return (
-      <div ref={listRef} className='mt-8 flex flex-col gap-6'>
-        {Array.from({ length: skeletonRowCount }).map((_, i) => (
-          <RowGrid key={i} columns={columns}>
-            <SkeletonRow columns={columns} />
-          </RowGrid>
-        ))}
+      <div ref={listRef}>
+        <SkeletonGrid />
       </div>
     );
   }

--- a/src/features/news/ui/SkeletonCard.tsx
+++ b/src/features/news/ui/SkeletonCard.tsx
@@ -3,7 +3,7 @@ import SkeletonBox from '@/shared/ui/SkeletonBox';
 export default function SkeletonCard() {
   return (
     <div className='flex h-[158px] w-full gap-4 overflow-hidden rounded-2xl border border-gray-200 p-6'>
-      <SkeletonBox className='h-full w-[102px] shrink-0' />
+      <SkeletonBox className='h-full w-[102px] shrink-0 rounded-lg' />
       <div className='flex flex-1 flex-col justify-center gap-2'>
         <SkeletonBox className='h-6 w-4/5' />
         <SkeletonBox className='h-4 w-1/3' />

--- a/src/features/news/ui/SkeletonGrid.tsx
+++ b/src/features/news/ui/SkeletonGrid.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { PAGE_SIZE } from '@/shared/constants/pageSize';
+import { useColumnCount } from '../hooks/useColumnCount';
+import SkeletonCard from './SkeletonCard';
+
+function RowGrid({
+  columns,
+  children,
+}: {
+  columns: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className='grid gap-6'
+      style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}>
+      {children}
+    </div>
+  );
+}
+
+export default function SkeletonGrid() {
+  const columns = useColumnCount();
+  const rowCount = Math.ceil(PAGE_SIZE / columns);
+
+  return (
+    <div className='mt-8 flex flex-col gap-6'>
+      {Array.from({ length: rowCount }).map((_, i) => (
+        <RowGrid key={i} columns={columns}>
+          {Array.from({ length: columns }).map((_, j) => (
+            <SkeletonCard key={j} />
+          ))}
+        </RowGrid>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 PR 개요

`NewsFeedSkeleton`과 `NewsList` isPending의 스켈레톤 그리드 구조를 통일하고, 이미지 스켈레톤의 border-radius를 실제 카드와 맞춰 시각적 일관성을 개선합니다.

## 🔍 관련 이슈

Closes #30

## 🔧 PR 유형

- [x] ♻️ refactor (리팩토링)

## ✨ 변경 사항

### 공유 스켈레톤 그리드 컴포넌트 추출

- `SkeletonGrid.tsx` 신규 생성 — `NewsList` isPending의 렌더링 로직을 독립 컴포넌트로 추출
  - `useColumnCount` 훅으로 동적 열 수 계산 (1 / 2 / 3열 반응형)
  - `RowGrid` + `SkeletonCard` 조합으로 `NewsList` virtualizer와 동일한 그리드 구조 사용

### 스켈레톤 구조 통일

- `NewsFeedSkeleton.tsx` — 기존 `<ul>` + Tailwind 반응형 클래스(`md:grid-cols-2 lg:grid-cols-3`) 방식 제거, `<SkeletonGrid />`로 교체
- `NewsList.tsx` — isPending 블록을 `<SkeletonGrid />`로 대체, 불필요해진 `PAGE_SIZE` import 제거

### 이미지 스켈레톤 border-radius 통일

- `SkeletonCard.tsx` — 이미지 영역 `SkeletonBox`에 `rounded-lg` 추가
  - 기존 `rounded` (4px) → `rounded-lg` (8px)로 수정, 실제 `NewsCard` 이미지와 일치

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

- `NewsList`의 `RowGrid`와 `SkeletonRow`는 virtualizer의 로더 행 렌더링에 여전히 사용되므로 그대로 유지했습니다.
- `NewsFeedSkeleton`은 Suspense fallback(SSR)으로 동작하므로 서버 컴포넌트를 유지했고, `SkeletonGrid`를 client 컴포넌트로 분리해 `useColumnCount` 훅을 사용하도록 했습니다.
