### PR TITLE
[feat] 리스트 top 버튼 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import QueryProvider from '@/shared/providers/QueryProvider';
 import './globals.css';
 import Header from '@/shared/ui/Header';
+import ScrollTopButton from '@/shared/ui/ScrollTopButton';
 
 export const metadata: Metadata = {
   title: 'AIPIA News',
@@ -20,6 +21,7 @@ export default function RootLayout({
         <div className='mx-auto w-full max-w-[1200px]'>
           <QueryProvider>{children}</QueryProvider>
         </div>
+        <ScrollTopButton />
       </body>
     </html>
   );

--- a/src/shared/ui/ScrollTopButton.tsx
+++ b/src/shared/ui/ScrollTopButton.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Button from './Button';
+
+export default function ScrollTopButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > 400);
+    };
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <Button
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      aria-label='맨 위로 이동'
+      className='fixed right-6 bottom-6 z-50 h-11 w-11 rounded-full p-0 shadow-lg'>
+      ↑
+    </Button>
+  );
+}


### PR DESCRIPTION
## 📌 PR 개요

가상 스크롤로 목록을 내려보다 상단으로 돌아가기 불편한 UX를 개선하기 위해, 스크롤 400px 초과 시 우하단에 고정 노출되는 "맨 위로 가기" 버튼을 구현했습니다.

## 🔍 관련 이슈

Closes #32

## 🔧 PR 유형

- [x] ✨ feat (새로운 기능)

## ✨ 변경 사항

### ScrollTopButton 컴포넌트 구현

- `src/shared/ui/ScrollTopButton.tsx` 신규 생성
  - `window.scrollY > 400` 조건으로 버튼 노출 여부 제어
  - `scroll` 이벤트에 `{ passive: true }` 옵션 적용으로 스크롤 성능 저하 방지
  - 클릭 시 `window.scrollTo({ top: 0, behavior: 'smooth' })`로 부드럽게 최상단 이동
  - 기존 공유 `Button` 컴포넌트 재사용, `className`으로 원형(`rounded-full`) 스타일 오버라이드
  - `aria-label='맨 위로 이동'` 접근성 처리

### 레이아웃 등록

- `src/app/layout.tsx` — `<body>` 최하단에 `<ScrollTopButton />` 추가, 모든 페이지에서 전역으로 동작

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음
