### PR TITLE
[refactor] API 호출 비효율 및 버그 개선 

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,11 +8,19 @@ import NewsFeedSkeleton from '@/features/news/ui/NewsFeedSkeleton';
 import NewsList from '@/features/news/ui/NewsList';
 import TabBar from '@/features/news/ui/TabBar';
 import { storiesQueryOptions } from '@/shared/lib/api';
+import { isStoryTab } from '@/shared/types/hackerNews';
+import type { StoryTab } from '@/shared/types/hackerNews';
 
-export default async function Home() {
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>;
+}) {
+  const { tab } = await searchParams;
+  const activeTab: StoryTab = isStoryTab(tab) ? tab : 'top';
+
   const queryClient = new QueryClient();
-
-  await queryClient.prefetchInfiniteQuery(storiesQueryOptions('top'));
+  await queryClient.prefetchInfiniteQuery(storiesQueryOptions(activeTab));
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/features/news/hooks/useNewsList.ts
+++ b/src/features/news/hooks/useNewsList.ts
@@ -13,7 +13,7 @@ export const useNewsList = () => {
     useStories(tab);
 
   return {
-    stories: data?.pages.flat() ?? [],
+    stories: data?.pages.flatMap((p) => p.stories) ?? [],
     isPending,
     isFetchingNextPage,
     fetchNextPage,

--- a/src/features/news/ui/SkeletonGrid.tsx
+++ b/src/features/news/ui/SkeletonGrid.tsx
@@ -1,37 +1,11 @@
-'use client';
-
 import { PAGE_SIZE } from '@/shared/constants/pageSize';
-import { useColumnCount } from '../hooks/useColumnCount';
 import SkeletonCard from './SkeletonCard';
 
-function RowGrid({
-  columns,
-  children,
-}: {
-  columns: number;
-  children: React.ReactNode;
-}) {
-  return (
-    <div
-      className='grid gap-6'
-      style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}>
-      {children}
-    </div>
-  );
-}
-
 export default function SkeletonGrid() {
-  const columns = useColumnCount();
-  const rowCount = Math.ceil(PAGE_SIZE / columns);
-
   return (
-    <div className='mt-8 flex flex-col gap-6'>
-      {Array.from({ length: rowCount }).map((_, i) => (
-        <RowGrid key={i} columns={columns}>
-          {Array.from({ length: columns }).map((_, j) => (
-            <SkeletonCard key={j} />
-          ))}
-        </RowGrid>
+    <div className='mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3'>
+      {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+        <SkeletonCard key={i} />
       ))}
     </div>
   );

--- a/src/shared/hooks/useStories.ts
+++ b/src/shared/hooks/useStories.ts
@@ -1,5 +1,4 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { PAGE_SIZE } from '@/shared/constants/pageSize';
 import { storiesQueryOptions } from '@/shared/lib/api';
 import { StoryTab } from '@/shared/types/hackerNews';
 
@@ -7,7 +6,7 @@ export const useStories = (tab: StoryTab) => {
   return useInfiniteQuery({
     ...storiesQueryOptions(tab),
     getNextPageParam: (lastPage, allPages) =>
-      lastPage.length < PAGE_SIZE ? undefined : allPages.length,
+      lastPage.hasMore ? allPages.length : undefined,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     throwOnError: true,

--- a/src/shared/lib/api.ts
+++ b/src/shared/lib/api.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { PAGE_SIZE } from '@/shared/constants/pageSize';
 import { QUERY_KEYS } from '@/shared/constants/queryKey';
 import { HackerNewsItem, StoryTab } from '@/shared/types/hackerNews';
@@ -33,15 +34,16 @@ const getCachedStoryIds = (tab: StoryTab): Promise<number[]> => {
   return promise;
 };
 
-export const fetchStory = async (
-  id: number,
-): Promise<HackerNewsItem | null> => {
-  const res = await fetch(`${BASE_URL}/item/${id}.json`);
-  if (!res.ok) {
-    throw new Error(`스토리(${id})를 불러오지 못했습니다`);
-  }
-  return res.json();
-};
+// React.cache: 동일 서버 렌더 내 generateMetadata + 컴포넌트 양쪽 호출 시 1회만 실행
+export const fetchStory = cache(
+  async (id: number): Promise<HackerNewsItem | null> => {
+    const res = await fetch(`${BASE_URL}/item/${id}.json`);
+    if (!res.ok) {
+      throw new Error(`스토리(${id})를 불러오지 못했습니다`);
+    }
+    return res.json();
+  },
+);
 
 export const storiesQueryOptions = (tab: StoryTab) => ({
   queryKey: [QUERY_KEYS.stories, tab],

--- a/src/shared/lib/api.ts
+++ b/src/shared/lib/api.ts
@@ -12,6 +12,27 @@ export const fetchStoryIds = async (tab: StoryTab): Promise<number[]> => {
   return res.json();
 };
 
+// 모듈 레벨 캐시
+// staleTime(5분)과 동일한 TTL로 무한 스크롤 중 중복 fetch 방지
+const ID_CACHE_TTL = 5 * 60 * 1000;
+const storyIdsCache = new Map<
+  StoryTab,
+  { promise: Promise<number[]>; expiry: number }
+>();
+
+const getCachedStoryIds = (tab: StoryTab): Promise<number[]> => {
+  const cached = storyIdsCache.get(tab);
+  if (cached && Date.now() < cached.expiry) {
+    return cached.promise;
+  }
+  const promise = fetchStoryIds(tab).catch((err) => {
+    storyIdsCache.delete(tab);
+    throw err;
+  });
+  storyIdsCache.set(tab, { promise, expiry: Date.now() + ID_CACHE_TTL });
+  return promise;
+};
+
 export const fetchStory = async (
   id: number,
 ): Promise<HackerNewsItem | null> => {
@@ -25,13 +46,16 @@ export const fetchStory = async (
 export const storiesQueryOptions = (tab: StoryTab) => ({
   queryKey: [QUERY_KEYS.stories, tab],
   queryFn: async ({ pageParam }: { pageParam: number }) => {
-    const allIds = await fetchStoryIds(tab);
+    const allIds = await getCachedStoryIds(tab);
     const pageIds = allIds.slice(
       pageParam * PAGE_SIZE,
       (pageParam + 1) * PAGE_SIZE,
     );
     const stories = await Promise.all(pageIds.map(fetchStory));
-    return stories.filter((s): s is HackerNewsItem => s !== null);
+    return {
+      stories: stories.filter((s): s is HackerNewsItem => s !== null),
+      hasMore: pageIds.length === PAGE_SIZE,
+    };
   },
   initialPageParam: 0,
 });

--- a/src/shared/types/hackerNews.ts
+++ b/src/shared/types/hackerNews.ts
@@ -1,5 +1,10 @@
 export type StoryTab = 'top' | 'new' | 'best';
 
+export const STORY_TABS: StoryTab[] = ['top', 'new', 'best'];
+
+export const isStoryTab = (value: unknown): value is StoryTab =>
+  STORY_TABS.includes(value as StoryTab);
+
 export interface HackerNewsItem {
   id: number;
   title: string;


### PR DESCRIPTION
## 📌 PR 개요

무한 스크롤 구조에서 발생하는 API 중복 호출, `hasNextPage` 판정 버그, 상세 페이지 중복 fetch, SSR prefetch 누락을 개선하고, 스켈레톤 초기 렌더 레이아웃 문제를 수정합니다.

## 🔍 관련 이슈

Closes #34

## 🔧 PR 유형

- [x] ♻️ refactor (리팩토링)


## ✨ 변경 사항

### API 중복 호출 방지 — `fetchStoryIds` 모듈 레벨 캐시

- `src/shared/lib/api.ts` — `getCachedStoryIds(tab)` 추가
  - 무한 스크롤로 페이지가 N개 쌓일 때마다 `fetchStoryIds`가 N번 호출되던 문제 해결
  - HN Firebase API가 `no-cache`로 응답해 브라우저 HTTP 캐시가 동작하지 않는 환경이므로, 모듈 레벨 `Map`으로 tab별 Promise를 캐시
  - TTL은 `staleTime`과 동일한 5분. fetch 실패 시 캐시 즉시 삭제해 다음 호출에서 재시도 가능

### `hasNextPage` 판정 버그 수정

- `src/shared/lib/api.ts` — `queryFn`이 `stories[]` 대신 `{ stories, hasMore }` 반환
  - `hasMore`는 `null` 필터링 이전 `pageIds.length === PAGE_SIZE` 기준
  - dead/deleted 스토리가 섞여 필터 후 길이가 PAGE_SIZE 미만이 되어도 무한 스크롤이 중간에 끊기지 않음
- `src/shared/hooks/useStories.ts` — `getNextPageParam`을 `lastPage.hasMore` 기반으로 변경, 불필요해진 `PAGE_SIZE` import 제거
- `src/features/news/hooks/useNewsList.ts` — `pages.flat()` → `pages.flatMap(p => p.stories)`로 데이터 접근 수정

### 상세 페이지 `fetchStory` 중복 호출 명시적 방지

- `src/shared/lib/api.ts` — `fetchStory`를 `React.cache()`로 감쌈
  - `generateMetadata`와 페이지 컴포넌트 양쪽에서 호출해도 동일 서버 렌더 내 1회만 실행 보장
  - Next.js `fetch` 자동 dedup에 의존하던 암묵적 동작을 코드 레벨에서 명시적으로 보장

### SSR prefetch active tab 반영

- `src/app/page.tsx` — `searchParams`에서 `tab` 값을 읽어 유효한 `StoryTab`이면 해당 탭, 아니면 `top`으로 prefetch
  - `?tab=new` 직접 진입 시 서버에서 `new` 탭 데이터를 prefetch해 클라이언트 재fetch 및 스켈레톤 이중 노출 방지
- `src/shared/types/hackerNews.ts` — `STORY_TABS` 상수, `isStoryTab` 타입 가드 추가 및 export

### 스켈레톤 초기 렌더 1열 문제 수정

- `src/features/news/ui/SkeletonGrid.tsx` — `useColumnCount` 훅 제거, Tailwind 반응형 클래스(`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`)로 대체
  - 기존 JS 기반 열 계산은 `useEffect` 실행 전 항상 1열로 렌더되는 문제가 있었음
  - 서버 컴포넌트로 전환해 SSR 시점부터 올바른 열 수 렌더

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

- `fetchStory`의 `React.cache()`는 서버 렌더 per-request 단위로 메모이제이션됩니다. 클라이언트 사이드(`useInfiniteQuery` queryFn)에서 호출될 때는 no-op으로 동작해 기존 동작에 영향 없습니다.
- `SkeletonGrid`의 Tailwind breakpoint(`sm: 640px`, `lg: 1024px`)는 `useColumnCount` 훅의 matchMedia 기준과 동일하게 맞췄습니다.
