### PR TITLE
[refactor] 목록으로 돌아가기 - 스크롤 위치 복원

### DIFF
--- a/src/features/news/ui/NewsCard.tsx
+++ b/src/features/news/ui/NewsCard.tsx
@@ -1,5 +1,9 @@
+'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { QUERY_KEYS } from '@/shared/constants/queryKey';
 import type { HackerNewsItem } from '@/shared/types/hackerNews';
 import { formatDate, toISODate } from '@/shared/utils/time';
 
@@ -10,11 +14,19 @@ interface NewsCardProps {
 
 export default function NewsCard({ item, preload = false }: NewsCardProps) {
   const { id, title, by, time } = item;
+  const searchParams = useSearchParams();
+  const tab = searchParams.get('tab') ?? QUERY_KEYS.top;
+
+  const handleClick = () => {
+    sessionStorage.setItem('scrollY', String(window.scrollY));
+    sessionStorage.setItem('scrollTab', tab);
+  };
 
   return (
     <article className='h-[158px] w-full rounded-2xl border border-gray-200'>
       <Link
         href={`/story/${id}`}
+        onClick={handleClick}
         aria-label={`${title}, 작성자 ${by}, ${formatDate(time)}`}
         className='flex h-full gap-4 p-6'>
         <div className='relative h-full w-[102px] shrink-0'>

--- a/src/features/news/ui/NewsList.tsx
+++ b/src/features/news/ui/NewsList.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+import { QUERY_KEYS } from '@/shared/constants/queryKey';
 import type { HackerNewsItem } from '@/shared/types/hackerNews';
 import { useNewsVirtualizer } from '../hooks/useNewsVirtualizer';
 import NewsCard from './NewsCard';
@@ -45,6 +48,9 @@ function SkeletonRow({ columns }: SkeletonRowProps) {
 }
 
 export default function NewsList() {
+  const searchParams = useSearchParams();
+  const tab = searchParams.get('tab') ?? QUERY_KEYS.top;
+
   const {
     listRef,
     virtualizer,
@@ -55,6 +61,20 @@ export default function NewsList() {
     stories,
     isPending,
   } = useNewsVirtualizer();
+
+  useEffect(() => {
+    if (isPending) {
+      return;
+    }
+    const savedY = sessionStorage.getItem('scrollY');
+    const savedTab = sessionStorage.getItem('scrollTab');
+    if (!savedY || savedTab !== tab) {
+      return;
+    }
+    sessionStorage.removeItem('scrollY');
+    sessionStorage.removeItem('scrollTab');
+    requestAnimationFrame(() => window.scrollTo(0, Number(savedY)));
+  }, [isPending, tab]);
 
   if (isPending) {
     return (


### PR DESCRIPTION
## 📌 PR 개요

상세 페이지에서 목록으로 돌아올 때 스크롤 위치가 복원되도록 구현했습니다. 카드 클릭 시 `sessionStorage`에 스크롤 Y값과 현재 탭을 저장하고, 목록 마운트 시 복원합니다.

## 🔍 관련 이슈

Closes #36

## 🔧 PR 유형

- [x] ♻️ refactor (리팩토링)

## ✨ 변경 사항

### 스크롤 위치 저장 — `NewsCard.tsx`

- `'use client'` 추가 및 `useSearchParams`로 현재 탭 읽기
- 카드 클릭 시 `sessionStorage`에 `scrollY`, `scrollTab` 저장
- 탭이 달라지면 복원하지 않도록 탭 값도 함께 저장

### 스크롤 위치 복원 — `NewsList.tsx`

- `useSearchParams`로 현재 탭을 직접 읽어 prop drilling 없이 처리
- `useEffect`에서 `isPending === false`일 때만 복원 시도
  - React Query 캐시가 있으면 정확하게 복원, 없으면 최상단에서 시작 (graceful degradation)
- `requestAnimationFrame`으로 virtualizer 레이아웃 완료 후 스크롤 호출
- 복원 완료 후 `sessionStorage` 항목 즉시 제거

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

- `router.back()` 대신 `sessionStorage` 방식을 채택한 이유: 상세 페이지 "목록으로 돌아가기"가 `Link href='/'`로 새 navigation을 발생시키기 때문에 히스토리 기반 복원이 불가능함
- 캐시 만료(gcTime 10분 초과) 시에는 `isPending === true`이므로 복원을 포기하고 최상단에서 시작하는 방식으로 graceful degradation 처리
