### PR TITLE
[refactor] 목록으로 돌아가기 — 스크롤 위치 복원 (개선)

### DIFF
--- a/src/app/story/[id]/page.tsx
+++ b/src/app/story/[id]/page.tsx
@@ -1,6 +1,5 @@
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import ArrowLeftIcon from '@/shared/assets/icons/arrow-left.svg';
+import BackToList from '@/features/news/ui/BackToList';
 import ExternalLinkIcon from '@/shared/assets/icons/external-link.svg';
 import { fetchStory } from '@/shared/lib/api';
 import Button from '@/shared/ui/Button';
@@ -18,10 +17,13 @@ export async function generateMetadata({
 
 export default async function DetailStory({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ tab?: string }>;
 }) {
   const { id } = await params;
+  const { tab } = await searchParams;
   const story = await fetchStory(Number(id));
 
   if (!story) {
@@ -35,12 +37,7 @@ export default async function DetailStory({
   return (
     <main className='py-8'>
       <nav aria-label='페이지 탐색' className='mb-8'>
-        <Link
-          href='/'
-          className='inline-flex items-center gap-1.5 text-sm text-gray-500 transition-colors hover:text-primary'>
-          <ArrowLeftIcon aria-hidden='true' focusable='false' />
-          목록으로 돌아가기
-        </Link>
+        <BackToList tab={tab} />
       </nav>
 
       <article aria-labelledby='story-title'>

--- a/src/features/news/ui/BackToList.tsx
+++ b/src/features/news/ui/BackToList.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import ArrowLeftIcon from '@/shared/assets/icons/arrow-left.svg';
+
+interface BackToListProps {
+  tab?: string;
+}
+
+export default function BackToList({ tab }: BackToListProps) {
+  const router = useRouter();
+  const fromListRef = useRef(false);
+
+  useEffect(() => {
+    if (sessionStorage.getItem('fromList')) {
+      fromListRef.current = true;
+      sessionStorage.removeItem('fromList');
+    }
+  }, []);
+
+  const handleClick = () => {
+    if (fromListRef.current) {
+      router.back();
+    } else {
+      router.push(tab ? `/?tab=${tab}` : '/');
+    }
+  };
+
+  return (
+    <button
+      type='button'
+      onClick={handleClick}
+      className='inline-flex cursor-pointer items-center gap-1.5 text-sm text-gray-500 transition-colors hover:text-primary'>
+      <ArrowLeftIcon aria-hidden='true' focusable='false' />
+      목록으로 돌아가기
+    </button>
+  );
+}

--- a/src/features/news/ui/NewsCard.tsx
+++ b/src/features/news/ui/NewsCard.tsx
@@ -18,14 +18,13 @@ export default function NewsCard({ item, preload = false }: NewsCardProps) {
   const tab = searchParams.get('tab') ?? QUERY_KEYS.top;
 
   const handleClick = () => {
-    sessionStorage.setItem('scrollY', String(window.scrollY));
-    sessionStorage.setItem('scrollTab', tab);
+    sessionStorage.setItem('fromList', '1');
   };
 
   return (
     <article className='h-[158px] w-full rounded-2xl border border-gray-200'>
       <Link
-        href={`/story/${id}`}
+        href={`/story/${id}?tab=${tab}`}
         onClick={handleClick}
         aria-label={`${title}, 작성자 ${by}, ${formatDate(time)}`}
         className='flex h-full gap-4 p-6'>

--- a/src/features/news/ui/NewsList.tsx
+++ b/src/features/news/ui/NewsList.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
-import { QUERY_KEYS } from '@/shared/constants/queryKey';
 import type { HackerNewsItem } from '@/shared/types/hackerNews';
 import { useNewsVirtualizer } from '../hooks/useNewsVirtualizer';
 import NewsCard from './NewsCard';
@@ -48,9 +45,6 @@ function SkeletonRow({ columns }: SkeletonRowProps) {
 }
 
 export default function NewsList() {
-  const searchParams = useSearchParams();
-  const tab = searchParams.get('tab') ?? QUERY_KEYS.top;
-
   const {
     listRef,
     virtualizer,
@@ -61,20 +55,6 @@ export default function NewsList() {
     stories,
     isPending,
   } = useNewsVirtualizer();
-
-  useEffect(() => {
-    if (isPending) {
-      return;
-    }
-    const savedY = sessionStorage.getItem('scrollY');
-    const savedTab = sessionStorage.getItem('scrollTab');
-    if (!savedY || savedTab !== tab) {
-      return;
-    }
-    sessionStorage.removeItem('scrollY');
-    sessionStorage.removeItem('scrollTab');
-    requestAnimationFrame(() => window.scrollTo(0, Number(savedY)));
-  }, [isPending, tab]);
 
   if (isPending) {
     return (

--- a/src/shared/assets/icons/arrow-up.svg
+++ b/src/shared/assets/icons/arrow-up.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 19V5M5 12l7-7 7 7"/>
+</svg>

--- a/src/shared/ui/ScrollTopButton.tsx
+++ b/src/shared/ui/ScrollTopButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import ArrowUpIcon from '@/shared/assets/icons/arrow-up.svg';
 import Button from './Button';
 
 export default function ScrollTopButton() {
@@ -24,7 +25,7 @@ export default function ScrollTopButton() {
       onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
       aria-label='맨 위로 이동'
       className='fixed right-6 bottom-6 z-50 h-11 w-11 rounded-full p-0 shadow-lg'>
-      ↑
+      <ArrowUpIcon aria-hidden='true' focusable='false' />
     </Button>
   );
 }


### PR DESCRIPTION
## 📌 PR 개요

상세 페이지의 "목록으로 돌아가기" 동작을 `sessionStorage` 기반 `scrollY` 복원에서 브라우저 history 기반 `router.back()`으로 전환했습니다. virtual scroll 환경에서 픽셀 기반 복원의 부정확성과 복잡도를 제거하고, bfcache에 위임해 더 단순하고 안정적인 UX를 제공합니다.

## 🔍 관련 이슈

Closes #38

## 🔧 PR 유형

- [x] ♻️ refactor (리팩토링)


## ✨ 변경 사항

### 돌아가기 컴포넌트 신설 — `BackToList.tsx`

- 상세 페이지의 `<Link href='/'>`를 클라이언트 컴포넌트인 `<button>` 기반 `BackToList`로 교체
- 리스트에서 진입한 경우 `router.back()`으로 브라우저 history 복원에 위임 (bfcache가 살아있으면 스크롤까지 복원, 없으면 graceful degradation으로 최상단)
- 외부/공유 링크로 직접 진입한 경우 `tab` 쿼리가 있으면 `/?tab={tab}`, 없으면 `/`로 `router.push`
- 진입 경로 판단은 `sessionStorage`의 `fromList` 플래그를 mount 시 한 번 읽고 즉시 제거하는 consume-on-read 방식 — `useRef`로 보관하여 불필요한 리렌더 없이 stale 안전 보장
- 기존 `Link`의 시각/접근성(arrow icon, gray-500 → hover:primary) 그대로 유지

### 진입 플래그 세팅 — `NewsCard.tsx`

- 카드 클릭 시 `sessionStorage`에 `fromList = '1'` 한 줄만 저장 (기존 `scrollY` / `scrollTab` 제거)
- `href`에 `?tab={tab}`를 포함하여 직접 진입 시에도 어떤 탭의 스토리인지 URL이 자체 기술

### 상세 페이지 props 전달 — `app/story/[id]/page.tsx`

- `searchParams`에서 `tab`을 추출하여 `<BackToList tab={tab} />`에 전달
- 더 이상 사용하지 않는 `Link` / `ArrowLeftIcon` import 제거

### scrollY 복원 로직 제거 — `NewsList.tsx`

- 마운트 시 `sessionStorage`에서 `scrollY` / `scrollTab`을 읽어 `requestAnimationFrame`으로 `window.scrollTo`하던 `useEffect` 블록 삭제
- 그에 딸린 `useSearchParams`, `useEffect`, `QUERY_KEYS` import도 함께 정리

### ScrollTopButton 아이콘 교체 — `ScrollTopButton.tsx`

- 유니코드 문자(`↑`)는 폰트에 따라 정렬이 흐트러지고 다른 아이콘(`arrow-left.svg`, `external-link.svg`) 컨벤션과 어긋나는 문제가 있어 SVG로 교체
- `src/shared/assets/icons/arrow-up.svg` 신규 추가 — 기존 `arrow-left.svg`와 동일한 lucide 스타일(16×16, viewBox 24, `currentColor`, stroke-width 2)
- `ScrollTopButton.tsx`에서 `ArrowUpIcon`을 컴포넌트로 import하여 사용 (`aria-hidden`, `focusable='false'`로 SR 노출 차단)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

- 처음에는 이슈 문서대로 "URL의 `tab` 쿼리 유무만으로 진입 경로 판단"을 시도했으나, `?tab=Best`이 포함된 공유 링크로 직접 진입하는 케이스에서 `router.back()`이 외부(예: 구글)로 빠져나가는 버그가 있어 보강이 필요했습니다.
- `history.length`(외부에서 진입해도 ≥ 2), `history.state`(Next.js가 내부적으로 덮어쓸 수 있음), `document.referrer`(SPA 네비게이션에서 갱신 안 됨)는 모두 신뢰할 수 없어 부적합. URL만으로는 원리적으로 구분 불가능하다고 판단했습니다.
- 결과적으로 `sessionStorage` 플래그를 도입했지만, 이전 구현(`scrollY` + `scrollTab` 두 키 + `useEffect` 복원 로직)에 비해 단일 boolean + consume-on-read로 훨씬 가볍고, 한 번의 카드 클릭당 한 번의 back만 동작하도록 구조적으로 보장됩니다.
