### PR TITLE
[refactor] 접근성 개선 — 랜드마크 / aria-* 값

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,9 +18,9 @@ export default function RootLayout({
     <html lang='ko' className='h-full antialiased'>
       <body className='flex min-h-full flex-col overflow-x-hidden px-4'>
         <Header />
-        <div className='mx-auto w-full max-w-[1200px]'>
+        <main className='mx-auto w-full max-w-[1200px]'>
           <QueryProvider>{children}</QueryProvider>
-        </div>
+        </main>
         <ScrollTopButton />
       </body>
     </html>

--- a/src/app/story/[id]/loading.tsx
+++ b/src/app/story/[id]/loading.tsx
@@ -2,7 +2,7 @@ import SkeletonBox from '@/shared/ui/SkeletonBox';
 
 export default function DetailStoryLoading() {
   return (
-    <main className='py-8'>
+    <div className='py-8'>
       <nav aria-label='페이지 탐색' className='mb-8'>
         <SkeletonBox className='h-5 w-32' />
       </nav>
@@ -43,6 +43,6 @@ export default function DetailStoryLoading() {
           <SkeletonBox className='h-10 w-30 rounded-lg' />
         </section>
       </article>
-    </main>
+    </div>
   );
 }

--- a/src/app/story/[id]/page.tsx
+++ b/src/app/story/[id]/page.tsx
@@ -35,7 +35,7 @@ export default async function DetailStory({
   const linkLabel = url ? '원문 보기' : 'HN에서 보기';
 
   return (
-    <main className='py-8'>
+    <div className='py-8'>
       <nav aria-label='페이지 탐색' className='mb-8'>
         <BackToList tab={tab} />
       </nav>
@@ -95,6 +95,6 @@ export default async function DetailStory({
           </Button>
         </section>
       </article>
-    </main>
+    </div>
   );
 }

--- a/src/features/news/ui/NewsList.tsx
+++ b/src/features/news/ui/NewsList.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
+import { QUERY_KEYS } from '@/shared/constants/queryKey';
 import type { HackerNewsItem } from '@/shared/types/hackerNews';
 import { useNewsVirtualizer } from '../hooks/useNewsVirtualizer';
 import NewsCard from './NewsCard';
@@ -45,6 +47,9 @@ function SkeletonRow({ columns }: SkeletonRowProps) {
 }
 
 export default function NewsList() {
+  const searchParams = useSearchParams();
+  const tabId = (searchParams.get('tab') ?? QUERY_KEYS.top).toLowerCase();
+
   const {
     listRef,
     virtualizer,
@@ -58,14 +63,23 @@ export default function NewsList() {
 
   if (isPending) {
     return (
-      <div ref={listRef}>
+      <div
+        ref={listRef}
+        role='tabpanel'
+        id={`tabpanel-${tabId}`}
+        aria-labelledby={`tab-${tabId}`}>
         <SkeletonGrid />
       </div>
     );
   }
 
   return (
-    <div ref={listRef} className='mt-8'>
+    <div
+      ref={listRef}
+      role='tabpanel'
+      id={`tabpanel-${tabId}`}
+      aria-labelledby={`tab-${tabId}`}
+      className='mt-8'>
       <div
         role='list'
         aria-label='뉴스 목록'


### PR DESCRIPTION
## 📌 PR 개요

Lighthouse 접근성 감사에서 검출된 두 가지 경고(메인 랜드마크 누락 / `aria-controls` 무효 참조)를 해결합니다. 보조 기술 사용자가 페이지의 본문 영역과 탭-콘텐츠 관계를 정확히 인식할 수 있도록 시맨틱과 ARIA 연결을 정리했습니다.

## 🔍 관련 이슈

Closes #40

## 🔧 PR 유형

- [x] ♻️ refactor (리팩토링)


## ✨ 변경 사항

### 메인 랜드마크 정리 — `app/layout.tsx`, `app/story/[id]/page.tsx`, `app/story/[id]/loading.tsx`

- `layout.tsx`의 콘텐츠 컨테이너(`<div className='mx-auto w-full max-w-[1200px]'>`)를 `<main>`으로 승격하여 모든 라우트가 단일 메인 랜드마크 하위에 들어가도록 함
- 기존에 상세 페이지(`page.tsx`)와 로딩 스켈레톤(`loading.tsx`)에 따로 있던 `<main>`은 `<div>`로 변경하여 중첩 방지
- 클래스/레이아웃은 그대로 유지

### tablist 패턴 완성 — `features/news/ui/NewsList.tsx`

- `TabBar`의 `aria-controls={tabpanel-${tabId}}`가 가리키던 ID가 실제 DOM에 없어 ARIA 값이 무효 처리되던 문제 해결
- `NewsList` wrapper에 `role='tabpanel'` / `id={tabpanel-${tabId}}` / `aria-labelledby={tab-${tabId}}` 부여 — `isPending` 분기와 정상 분기 양쪽에 동일하게 적용
- `useSearchParams`로 현재 탭을 읽어 lowercase로 정규화 (`tabId`) — `TabBar`의 ID 컨벤션과 일치시킴

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고

- `<main>`은 문서당 하나만 허용되므로, layout에 단일 `<main>`을 두는 옵션 A를 채택. 페이지마다 명시적으로 두는 옵션 B는 누락 위험과 중첩 가능성이 있어 제외함
- `aria-controls`를 제거하고 일반 nav로 단순화하는 옵션도 있었지만, `useTabBar`에 이미 키보드 navigation(ArrowLeft/Right/Home/End)이 구현되어 있어 tablist 패턴을 완성하는 쪽이 자연스러움
- 설계 의도 및 옵션 비교는 `docs/issue/issue-a11y.md` 참고
